### PR TITLE
ml: kMaxInputNum increase to 64.

### DIFF
--- a/tensorflow/lite/micro/kernels/concatenation.cc
+++ b/tensorflow/lite/micro/kernels/concatenation.cc
@@ -28,7 +28,7 @@ namespace tflite {
 
 namespace {
 
-constexpr int kMaxInputNum = 10;  // Maximum number of input tensors
+constexpr int kMaxInputNum = 64;  // Maximum number of input tensors
 constexpr int kOutputTensor = 0;
 
 struct OpData {


### PR DESCRIPTION
concatenation limit is too small for many models.